### PR TITLE
Handle authenticated users when HYPR is used as a second factor

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.hypr.common/src/main/java/org/wso2/carbon/identity/application/authenticator/hypr/common/constants/HyprAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.hypr.common/src/main/java/org/wso2/carbon/identity/application/authenticator/hypr/common/constants/HyprAuthenticatorConstants.java
@@ -168,6 +168,7 @@ public class HyprAuthenticatorConstants {
             INVALID_TOKEN("INVALID_TOKEN", "Authentication failed due to an internal server error. " +
                     "To fix this, contact your system administrator."),
             INVALID_REQUEST("INVALID_REQUEST", "Invalid username provided"),
+            INVALID_USER("INVALID_USER", "User does not exist in HYPR"),
             PENDING("PENDING", "Authentication with HYPR is in progress. Awaiting for the user to " +
                     "authenticate via the registered smart device"),
             COMPLETED("COMPLETED", "Authentication successfully completed."),

--- a/components/org.wso2.carbon.identity.application.authenticator.hypr/pom.xml
+++ b/components/org.wso2.carbon.identity.application.authenticator.hypr/pom.xml
@@ -114,6 +114,8 @@
                             version="${identity.framework.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.model;
                             version="${identity.framework.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.config.model;
+                            version="${identity.framework.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.model;
                             version="${identity.framework.package.import.version.range}",
                             org.wso2.carbon.identity.core; version="${identity.framework.package.import.version.range}"

--- a/components/org.wso2.carbon.identity.application.authenticator.hypr/src/main/java/org/wso2/carbon/identity/application/authenticator/hypr/HyprAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.hypr/src/main/java/org/wso2/carbon/identity/application/authenticator/hypr/HyprAuthenticator.java
@@ -170,13 +170,7 @@ public class HyprAuthenticator extends AbstractApplicationAuthenticator implemen
                                                  AuthenticationContext context) throws AuthenticationFailedException {
 
         try {
-            if (context.getLastAuthenticatedUser() != null) {
-                // If the user is already authenticated, initiate HYPR authentication request.
-                initiateHYPRAuthenticationRequest(request, response, context);
-            } else {
-                // If the user is not authenticated, redirect to the HYPR login page to prompt username.
-                redirectHYPRLoginPage(response, context, null);
-            }
+            redirectHYPRLoginPage(response, context, null);
         } catch (AuthenticationFailedException e) {
             String errorMessage = "Error occurred when trying to redirect user to the login page.";
             throw new AuthenticationFailedException(errorMessage, e);
@@ -236,7 +230,7 @@ public class HyprAuthenticator extends AbstractApplicationAuthenticator implemen
             // loop through the authentication steps and find the authenticated user from the subject identifier step.
             if (stepConfigMap != null) {
                 for (StepConfig stepConfig : stepConfigMap.values()) {
-                    if (stepConfig.getAuthenticatedUser() != null && stepConfig.isSubjectIdentifierStep()) {
+                    if (stepConfig.isSubjectIdentifierStep() && stepConfig.getAuthenticatedUser() != null ) {
                         username = stepConfig.getAuthenticatedUser().getUserName();
                         break;
                     }
@@ -427,8 +421,13 @@ public class HyprAuthenticator extends AbstractApplicationAuthenticator implemen
                 return AuthenticatorFlowStatus.INCOMPLETE;
             }
         } else {
-            // Redirect the user to the login page.
-            initiateAuthenticationRequest(request, response, context);
+            if (context.getLastAuthenticatedUser() != null) {
+                // If the user is already authenticated, initiate HYPR authentication request.
+                initiateHYPRAuthenticationRequest(request, response, context);
+            } else {
+                // If the user is not authenticated, redirect to the HYPR login page to prompt username.
+                initiateAuthenticationRequest(request, response, context);
+            }
             return AuthenticatorFlowStatus.INCOMPLETE;
         }
         return super.process(request, response, context);


### PR DESCRIPTION
This pr add the implementations required to get the username of the authenticated user if there is an already authenticated user. 