### PR TITLE
Improve canHandle method

### DIFF
--- a/components/org.wso2.carbon.identity.application.authenticator.hypr.common/src/main/java/org/wso2/carbon/identity/application/authenticator/hypr/common/constants/HyprAuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.hypr.common/src/main/java/org/wso2/carbon/identity/application/authenticator/hypr/common/constants/HyprAuthenticatorConstants.java
@@ -135,6 +135,8 @@ public class HyprAuthenticatorConstants {
         public static final String SESSION_DATA_KEY = "sessionDataKey";
         public static final String TENANT_DOMAIN = "tenantDomain";
         public static final String USERNAME = "username";
+        public static final String AUTH_TYPE = "authType";
+        public static final String AUTH_TYPE_HYPR = "hypr";
 
         public static final String CORRELATION_ID_KEY = "Correlation-ID";
         public static final String HYPR_API_PREFIX = "HYPR-API-";

--- a/components/org.wso2.carbon.identity.application.authenticator.hypr/src/main/java/org/wso2/carbon/identity/application/authenticator/hypr/HyprAuthenticator.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.hypr/src/main/java/org/wso2/carbon/identity/application/authenticator/hypr/HyprAuthenticator.java
@@ -164,7 +164,9 @@ public class HyprAuthenticator extends AbstractApplicationAuthenticator implemen
     public boolean canHandle(HttpServletRequest request) {
 
         // With HYPR if sessionDataKey is not received then the entire flow will break as it highly relied on it.
-        return request.getParameter(HYPR.SESSION_DATA_KEY) != null;
+        return StringUtils.isNotBlank(request.getParameter(HYPR.AUTH_TYPE)) &&
+                request.getParameter(HYPR.AUTH_TYPE).equals(HYPR.AUTH_TYPE_HYPR) &&
+                StringUtils.isNotBlank(request.getParameter(HYPR.SESSION_DATA_KEY));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.application.authenticator.hypr/src/test/java/org/wso2/carbon/identity/application/authenticator/hypr/HyprAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.application.authenticator.hypr/src/test/java/org/wso2/carbon/identity/application/authenticator/hypr/HyprAuthenticatorTest.java
@@ -67,6 +67,7 @@ public class HyprAuthenticatorTest {
     private static final String appID = "testApp";
     private static final String baseUrl = "https://wso2.hypr.com";
     private static final String sessionDataKey = "testSessionKey";
+    private static final String authType = "hypr";
     private static final String deviceId = "testDeviceID";
     private static final String protocolVersion = null;
     private static final String modelNumber = "testModelNumber";
@@ -157,11 +158,22 @@ public class HyprAuthenticatorTest {
     @Test(description = "Test case for canHandle() method.")
     public void testCanHandle() {
 
+        // The request contains the session data key and the auth type.
         when(httpServletRequest.getParameter(HyprAuthenticatorConstants.HYPR.SESSION_DATA_KEY))
                 .thenReturn(sessionDataKey);
+        when(httpServletRequest.getParameter(HyprAuthenticatorConstants.HYPR.AUTH_TYPE))
+                .thenReturn(authType);
         Assert.assertTrue(hyprAuthenticator.canHandle(httpServletRequest));
 
+        // The request does not contain the session data key.
         when(httpServletRequest.getParameter(HyprAuthenticatorConstants.HYPR.SESSION_DATA_KEY)).thenReturn(null);
+        Assert.assertFalse(hyprAuthenticator.canHandle(httpServletRequest));
+
+        // The request does not contain the auth type.
+        when(httpServletRequest.getParameter(HyprAuthenticatorConstants.HYPR.SESSION_DATA_KEY))
+                .thenReturn(sessionDataKey);
+        when(httpServletRequest.getParameter(HyprAuthenticatorConstants.HYPR.AUTH_TYPE))
+                .thenReturn(null);
         Assert.assertFalse(hyprAuthenticator.canHandle(httpServletRequest));
     }
 


### PR DESCRIPTION
### Purpose
> This improves the canHandle method of HYPR to additionally check the `authType` parameter to distinguish the handling behavior from other authenticators

### Related Issues
- Issue https://github.com/wso2-enterprise/asgardeo-product/issues/21750

### Related PRs
- Related PR https://github.com/wso2/identity-apps/pull/5453